### PR TITLE
Refactor

### DIFF
--- a/example/index.ts
+++ b/example/index.ts
@@ -1,4 +1,4 @@
-import { startApp } from '../src/lib/app';
+import { createApp, startApp } from '../src/lib/app';
 import { TRawManifest } from '../src/types';
 import { prepareConfig } from '../src/lib/config';
 
@@ -37,6 +37,15 @@ const manifest: TRawManifest = {
   },
 };
 
-startApp(config, manifest)
-  .then(() => console.log('ready'))
-  .catch((e) => console.log('error: ', e));
+const main = async () => {
+  const app = createApp(config, manifest);
+  await startApp(app);
+  console.log('App started');
+  // startApp(config, manifest)
+  //   .then(() => console.log('ready'))
+  //   .catch((e) => console.log('error: ', e));
+};
+
+if (require.main === module) {
+  main();
+}

--- a/example/index.ts
+++ b/example/index.ts
@@ -1,4 +1,4 @@
-import { createApp, startApp } from '../src/lib/app';
+import { createApp, startApp } from '../src';
 import { TRawManifest } from '../src/types';
 import { prepareConfig } from '../src/lib/config';
 
@@ -18,11 +18,6 @@ const manifest: TRawManifest = {
           'SELECT NOW()'
         );
         return { resource: response[0] };
-        // return {
-        //   resource: {
-        //     test: 'work',
-        //   },
-        // };
       },
     },
   },
@@ -41,9 +36,6 @@ const main = async () => {
   const app = createApp(config, manifest);
   await startApp(app);
   console.log('App started');
-  // startApp(config, manifest)
-  //   .then(() => console.log('ready'))
-  //   .catch((e) => console.log('error: ', e));
 };
 
 if (require.main === module) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/app';
+export { TDispatch } from './lib/dispatch';

--- a/src/lib/agent.ts
+++ b/src/lib/agent.ts
@@ -1,0 +1,21 @@
+import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
+import axiosRetry from 'axios-retry';
+
+export type TAgentConfig = Pick<AxiosRequestConfig, 'baseURL' | 'auth'>;
+
+export type TAgent = AxiosInstance;
+
+export const createAgent = (config: TAgentConfig): TAgent => {
+  const clientInstance = axios.create(config);
+  axiosRetry(clientInstance, {
+    retries: 10,
+    retryDelay: (retryCount) => {
+      return retryCount * 1000;
+    },
+    retryCondition: () => {
+      console.log('Awaiting aidbox server...');
+      return true;
+    },
+  });
+  return clientInstance;
+};

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -1,30 +1,14 @@
-import yaml from 'js-yaml';
+import { TConfig, TPatchedManifest, TRawManifest } from '../types';
 
-import {
-  EAccept,
-  EOperation,
-  TConfig,
-  TContext,
-  TDispatchFn,
-  TMessage,
-  TPatchedManifest,
-  TRawManifest,
-} from '../types';
-
+import { createAgent, TAgent } from './agent';
 import { validateConfig } from './config';
-import { makeContext } from './context';
-import {
-  createAgent,
-  createServer,
-  startServer,
-  TAgent,
-  TServer,
-} from './http';
-import { ensureManifest, patchManifest, validateManifest } from './manifest';
+import { createContext } from './context';
+import { createDispatch } from './dispatch';
+import { createServer, startServer, TServer } from './http';
+import { patchManifest, syncManifest, validateManifest } from './manifest';
 
 export type TApp = {
   readonly httpServer: TServer;
-  readonly context: TContext;
   readonly agent: TAgent;
   readonly config: TConfig;
   readonly patchedManifest: TPatchedManifest;
@@ -43,16 +27,25 @@ export const createApp = (config: TConfig, manifest: TRawManifest): TApp => {
     throw new Error(manifestValidation.error);
   }
 
-  const agent = createAgent(config);
-  const context = makeContext(agent);
+  const agent = createAgent({
+    baseURL: config.AIDBOX_URL,
+    auth: {
+      username: config.AIDBOX_CLIENT_ID,
+      password: config.AIDBOX_CLIENT_SECRET,
+    },
+  });
   const { subscriptionHandlers, patchedManifest } = patchManifest(manifest);
-  const httpServer = createServer(
-    dispatch(config, patchedManifest, context, subscriptionHandlers)
+  const context = createContext(agent);
+  const dispatch = createDispatch(
+    config,
+    patchedManifest,
+    context,
+    subscriptionHandlers
   );
+  const httpServer = createServer(dispatch);
 
   return {
     httpServer,
-    context,
     agent,
     config,
     patchedManifest,
@@ -60,123 +53,21 @@ export const createApp = (config: TConfig, manifest: TRawManifest): TApp => {
 };
 
 export const startApp = async (app: TApp) => {
-  // eslint-disable-next-line functional/no-let
-  let isReady;
+  const { agent, config, patchedManifest, httpServer } = app;
   try {
-    isReady = await app.context.request(
-      {
-        url: '/__healthcheck',
-      },
-      false
-    );
-  } catch (e) {
-    console.log(e, 'error');
+    await waitForAidboxServer(agent);
+  } catch (err) {
+    console.error(`Aidbox server is unreachable.`);
+    process.exit(1);
+    return;
   }
-  if (!isReady) {
-    console.log('aidbox not ready', 'error');
-    process.exit(0);
-  }
-
-  await ensureManifest(app.agent, app.config, app.patchedManifest);
-  await startServer(app.httpServer);
+  await syncManifest(agent, config, patchedManifest);
+  await startServer(httpServer);
 };
 
-const resolveContentType = (msg: TMessage) => {
-  switch (msg.request?.headers?.accept) {
-    case EAccept.YAML:
-    case EAccept.TEXT:
-      return msg.request.headers.accept;
-    default:
-      return EAccept.JSON;
-  }
-};
-
-const checkAuthHeader = (
-  appId: string,
-  appSecret: string,
-  authHeader?: string
-) => {
-  if (!authHeader) {
-    return false;
-  }
-  const [auth] = authHeader.split(' ').slice(1, 2);
-  return auth === Buffer.from(`${appId}:${appSecret}`).toString('base64');
-};
-
-const dispatch: TDispatchFn = (
-  config,
-  manifest,
-  context,
-  subscriptionHandlers
-) => (req, res) => {
-  const sendResponse = (
-    text: string,
-    status = 200,
-    headers: Record<string, string> = {}
-  ) => {
-    // eslint-disable-next-line functional/immutable-data
-    res.statusCode = status;
-    Object.keys(headers).forEach((k: string) => {
-      res.setHeader(k, headers[k]);
-    });
-    res.end(text);
-  };
-
-  // eslint-disable-next-line functional/no-let
-  let reqBody = '';
-  req.on('data', (chunk) => {
-    reqBody += chunk.toString();
-  });
-  req.on('end', async () => {
-    console.log(reqBody);
-    try {
-      const msg = JSON.parse(reqBody) as TMessage;
-      res.setHeader('Content-Type', resolveContentType(msg));
-
-      if (
-        !checkAuthHeader(
-          config.APP_ID,
-          config.APP_SECRET,
-          req.headers.authorization
-        )
-      ) {
-        sendResponse(JSON.stringify({ message: 'Access Denied' }), 403);
-        return;
-      }
-
-      const operation = msg.type;
-
-      if (operation === EOperation.SUBSCRIPTION) {
-        const handlerId = msg.handler as string;
-        if (subscriptionHandlers[handlerId]) {
-          subscriptionHandlers[handlerId](context, msg);
-          sendResponse(JSON.stringify({ status: 'start subs' }));
-        }
-        return;
-      }
-
-      const operationId = msg.operation?.id;
-      if (
-        operation === EOperation.OPERATION &&
-        operationId &&
-        manifest.operations[operationId]
-      ) {
-        const { handler } = manifest.operations[operationId];
-        const { status, headers, resource, body } = await handler(context, msg);
-        if (msg.request.headers.accept === 'text/yaml') {
-          sendResponse(yaml.dump(resource, { noRefs: true }), status, headers);
-          return;
-        } else if (body) {
-          sendResponse(body, status, headers);
-          return;
-        } else {
-          sendResponse(JSON.stringify(resource), status, headers);
-          return;
-        }
-      }
-    } catch (e) {
-      console.log(e);
-      sendResponse(JSON.stringify(e));
-    }
+const waitForAidboxServer = async (agent: TAgent) => {
+  await agent.request({
+    url: '/__healthcheck',
+    responseType: 'text',
   });
 };

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -1,39 +1,18 @@
-import { AxiosRequestConfig } from 'axios';
 import yaml from 'js-yaml';
 
 import {
   EAccept,
   EOperation,
   TConfig,
-  TContext,
   TDispatchFn,
   TMessage,
   TRawManifest,
 } from '../types';
 
 import { validateConfig } from './config';
-import { createAgent, createServer, startServer, TAgent } from './http';
+import { makeContext } from './context';
+import { createAgent, createServer, startServer } from './http';
 import { ensureManifest, patchManifest, validateManifest } from './manifest';
-
-const makeContext = (agent: TAgent): TContext => {
-  const request = (config: AxiosRequestConfig, jsonOverride = true) => {
-    return agent.request({
-      ...config,
-      responseType: jsonOverride ? 'json' : 'text',
-    });
-  };
-
-  const psql = async <T = any>(query: string): Promise<readonly T[]> => {
-    const response = await request({
-      url: '/$psql',
-      method: 'post',
-      data: { query },
-    });
-    return response.data[0].result;
-  };
-
-  return { request, psql };
-};
 
 export const startApp = async (
   config: TConfig,

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -2,9 +2,9 @@ import { AxiosRequestConfig } from 'axios';
 
 import { TContext } from '../types';
 
-import { TAgent } from './http';
+import { TAgent } from './agent';
 
-export const makeContext = (agent: TAgent): TContext => {
+export const createContext = (agent: TAgent): TContext => {
   const request = (config: AxiosRequestConfig, jsonOverride = true) => {
     return agent.request({
       ...config,

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -1,0 +1,25 @@
+import { AxiosRequestConfig } from 'axios';
+
+import { TContext } from '../types';
+
+import { TAgent } from './http';
+
+export const makeContext = (agent: TAgent): TContext => {
+  const request = (config: AxiosRequestConfig, jsonOverride = true) => {
+    return agent.request({
+      ...config,
+      responseType: jsonOverride ? 'json' : 'text',
+    });
+  };
+
+  const psql = async <T = any>(query: string): Promise<readonly T[]> => {
+    const response = await request({
+      url: '/$psql',
+      method: 'post',
+      data: { query },
+    });
+    return response.data[0].result;
+  };
+
+  return { request, psql };
+};

--- a/src/lib/dispatch.ts
+++ b/src/lib/dispatch.ts
@@ -1,0 +1,120 @@
+import { RequestListener } from 'http';
+
+import yaml from 'js-yaml';
+
+import {
+  EAccept,
+  EOperation,
+  TConfig,
+  TContext,
+  TMessage,
+  TPatchedManifest,
+  TSubscriptionHandlers,
+} from '../types';
+
+export type TDispatch = (
+  config: TConfig,
+  manifest: TPatchedManifest,
+  context: TContext,
+  subscriptionHandlers: TSubscriptionHandlers
+) => RequestListener;
+
+export const createDispatch: TDispatch = (
+  config,
+  manifest,
+  context,
+  subscriptionHandlers
+) => (req, res) => {
+  const sendResponse = (
+    text: string,
+    status = 200,
+    headers: Record<string, string> = {}
+  ) => {
+    // eslint-disable-next-line functional/immutable-data
+    res.statusCode = status;
+    Object.keys(headers).forEach((k: string) => {
+      res.setHeader(k, headers[k]);
+    });
+    res.end(text);
+  };
+
+  // eslint-disable-next-line functional/no-let
+  let reqBody = '';
+  req.on('data', (chunk) => {
+    reqBody += chunk.toString();
+  });
+  req.on('end', async () => {
+    console.log(reqBody);
+    try {
+      const msg = JSON.parse(reqBody) as TMessage;
+      res.setHeader('Content-Type', resolveContentType(msg));
+
+      if (
+        !checkAuthHeader(
+          config.APP_ID,
+          config.APP_SECRET,
+          req.headers.authorization
+        )
+      ) {
+        sendResponse(JSON.stringify({ message: 'Access Denied' }), 403);
+        return;
+      }
+
+      const operation = msg.type;
+
+      if (operation === EOperation.SUBSCRIPTION) {
+        const handlerId = msg.handler as string;
+        if (subscriptionHandlers[handlerId]) {
+          subscriptionHandlers[handlerId](context, msg);
+          sendResponse(JSON.stringify({ status: 'start subs' }));
+        }
+        return;
+      }
+
+      const operationId = msg.operation?.id;
+      if (
+        operation === EOperation.OPERATION &&
+        operationId &&
+        manifest.operations[operationId]
+      ) {
+        const { handler } = manifest.operations[operationId];
+        const { status, headers, resource, body } = await handler(context, msg);
+        if (msg.request.headers.accept === 'text/yaml') {
+          sendResponse(yaml.dump(resource, { noRefs: true }), status, headers);
+          return;
+        } else if (body) {
+          sendResponse(body, status, headers);
+          return;
+        } else {
+          sendResponse(JSON.stringify(resource), status, headers);
+          return;
+        }
+      }
+    } catch (e) {
+      console.log(e);
+      sendResponse(JSON.stringify(e));
+    }
+  });
+};
+
+const resolveContentType = (msg: TMessage) => {
+  switch (msg.request?.headers?.accept) {
+    case EAccept.YAML:
+    case EAccept.TEXT:
+      return msg.request.headers.accept;
+    default:
+      return EAccept.JSON;
+  }
+};
+
+const checkAuthHeader = (
+  appId: string,
+  appSecret: string,
+  authHeader?: string
+) => {
+  if (!authHeader) {
+    return false;
+  }
+  const [auth] = authHeader.split(' ').slice(1, 2);
+  return auth === Buffer.from(`${appId}:${appSecret}`).toString('base64');
+};

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -1,12 +1,6 @@
 import http, { RequestListener, Server } from 'http';
 
-import axios, { AxiosInstance } from 'axios';
-import axiosRetry from 'axios-retry';
-
-import { TConfig } from '../types';
-
 export type TServer = Server;
-export type TAgent = AxiosInstance;
 
 export const createServer = (dispatch: RequestListener): TServer =>
   http.createServer((req, res) => {
@@ -31,33 +25,4 @@ export const startServer = (
         resolve(server);
       });
   });
-};
-
-export const createAgent = (config: TConfig): TAgent => {
-  const clientInstance = axios.create({
-    baseURL: config.AIDBOX_URL,
-    auth: {
-      username: config.AIDBOX_CLIENT_ID,
-      password: config.AIDBOX_CLIENT_SECRET,
-    },
-  });
-  //  clientInstance.interceptors.response.use(
-  //     (response) => {
-  //       return response;
-  //     },
-  //     (error) => {
-  //       return Promise.reject(error);
-  //     },
-  //   );
-  axiosRetry(clientInstance, {
-    retries: 10,
-    retryCondition: (error) => {
-      console.log('wait while aidbox will be ready');
-      return error.config.url === '/__healthcheck';
-    },
-    retryDelay: (retryCount) => {
-      return retryCount * 1000;
-    },
-  });
-  return clientInstance;
 };

--- a/src/lib/manifest.ts
+++ b/src/lib/manifest.ts
@@ -5,7 +5,7 @@ import {
   TSubscriptionHandlers,
 } from '../types';
 
-import { TAgent } from './http';
+import { TAgent } from './agent';
 
 export const validateManifest = (
   manifest: TRawManifest
@@ -66,27 +66,25 @@ export const patchManifest = (
   };
 };
 
-export const ensureManifest = async (
-  clientInstance: TAgent,
+export const syncManifest = async (
+  agent: TAgent,
   config: TConfig,
   manifest: TPatchedManifest
 ) => {
-  const mergedManifest = {
-    resourceType: 'App',
-    apiVersion: 1,
-    type: 'app',
-    id: config.APP_ID,
-    endpoint: {
-      url: `${config.APP_URL}/aidbox`,
-      type: 'http-rpc',
-      secret: config.APP_SECRET,
-    },
-    ...manifest,
-  };
-
-  return await clientInstance.request({
+  return await agent.request({
     url: '/App',
     method: 'put',
-    data: mergedManifest,
+    data: {
+      resourceType: 'App',
+      apiVersion: 1,
+      type: 'app',
+      id: config.APP_ID,
+      endpoint: {
+        url: `${config.APP_URL}/aidbox`,
+        type: 'http-rpc',
+        secret: config.APP_SECRET,
+      },
+      ...manifest,
+    },
   });
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,3 @@
-import { RequestListener } from 'http';
-
 import { AxiosRequestConfig, AxiosResponse } from 'axios';
 
 export type ProcessEnv = {
@@ -84,13 +82,6 @@ export enum EOperation {
   OPERATION = 'operation',
   SUBSCRIPTION = 'subscription',
 }
-
-export type TDispatchFn = (
-  config: TConfig,
-  manifest: TPatchedManifest,
-  context: TContext,
-  subscriptionHandlers: TSubscriptionHandlers
-) => RequestListener;
 
 export type TMessage = {
   readonly type: EOperation;


### PR DESCRIPTION
* Разбивает `startApp` на две функции - синхронную `createApp` (валидирует config/manifest, создает context/dispatch), и асинхронную `startApp` (ожидает aidbox-server, дождавшись - синхронизирует манифест и запускает http-server)
* Разбивает код на более мелкие модули (отдельно context/config/dispatch/app).