### PR TITLE
Display response body when manifest sync failed

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -32,11 +32,25 @@ export const startApp = async (app: TApp, port: number): Promise<void> => {
     entities: describe(manifest.entities),
     resources: describe(manifest.resources),
   });
-  await ctx.request({
-    url: "/App",
-    method: "PUT",
-    data: { ...manifest, type: "app", resourceType: "App" },
-  });
+  await ctx
+    .request({
+      url: '/App',
+      method: 'PUT',
+      data: { ...manifest, type: 'app', resourceType: 'App' },
+    })
+    .then((response) => {
+      debug('Manifest is updated');
+    })
+    .catch((error) => {
+      if (error.response?.data) {
+        debug(
+          'Manifest sync failed: %s\n%O',
+          error.response.status,
+          JSON.stringify(error.response.data)
+        );
+      }
+      throw error;
+    });
   await new Promise<void>((resolve) => app.listen(port, resolve));
   debug("App started on port %d", port);
 };


### PR DESCRIPTION
- **Improve error displaying** (Bug fix, feature, docs update, ...)
Not sure this is the best way to do it, but now if there is any response from Aidbox, it's hidden.
Axios docs: https://axios-http.com/docs/handling_errors

- **What is the current behavior?**
Currently if request were failed, we are not able to see full Aidbox response in a error message:
```
data: {
      resourceType: 'OperationOutcome',
      text: [Object],
      issue: [Array]
    }
```

- **What is the new behavior?**
Now in log firstly goes:
```
Manifest sync failed: 409
'{"resourceType":"OperationOutcome","id":"duplicate","text":{"status":"generated","div":"Resource with same id already exists"},"issue":[{"severity":"fatal","code":"duplicate","diagnostics":"Resource with same id already exists"}]}'
```

Then the same error is thrown.